### PR TITLE
Add spacing between year and content

### DIFF
--- a/src/components/education-entry.tsx
+++ b/src/components/education-entry.tsx
@@ -3,7 +3,7 @@ import { Education } from "@/data/education";
 export function EducationEntry({ education }: { education: Education }) {
   return (
     <div>
-      <div className="grid grid-cols-4 mb-2">
+      <div className="grid grid-cols-4 gap-x-2 mb-2">
         <span className="text-xs text-zinc-500 mt-1">{education.year}</span>
         <div className="col-span-3">
           <h3 className="text-base mb-1 font-serif">{education.institution}</h3>

--- a/src/components/experience-entry.tsx
+++ b/src/components/experience-entry.tsx
@@ -2,7 +2,7 @@ import { Experience } from "@/data/experience";
 
 export function ExperienceEntry({ experience }: { experience: Experience }) {
   return (
-    <div className="grid grid-cols-4">
+    <div className="grid grid-cols-4 gap-x-2">
       <span className="text-xs text-zinc-500 mt-1">{experience.date}</span>
       <div className="col-span-3 flex flex-col">
         <h3 className="text-base font-serif">


### PR DESCRIPTION
Add small gap between year and content for publications and education.

Before:
<img width="542" alt="Screenshot 2025-01-11 at 1 43 32 PM" src="https://github.com/user-attachments/assets/718011e4-fcc8-4f9b-9cfa-b586bcdf2075" />

After:
<img width="544" alt="Screenshot 2025-01-11 at 1 44 20 PM" src="https://github.com/user-attachments/assets/b24ebc24-735a-497a-9b2c-7b07d3d90d84" />
