### PR TITLE
Display publications and portfolio in column on mobile

### DIFF
--- a/src/components/portfolio-entry.tsx
+++ b/src/components/portfolio-entry.tsx
@@ -4,7 +4,7 @@ import { Portfolio } from "@/data/portfolio";
 
 export function PortfolioEntry({ portfolio }: { portfolio: Portfolio }) {
   return (
-    <div className="flex flex-row gap-6">
+    <div className="flex flex-col sm:flex-row gap-6">
       {portfolio.imageUrl && (
         <div className="w-1/4 min-w-[160px] relative">
           <Image

--- a/src/components/publication-entry.tsx
+++ b/src/components/publication-entry.tsx
@@ -8,9 +8,9 @@ export function PublicationEntry({
   publication: Publication;
 }) {
   return (
-    <div className="flex flex-row gap-6">
+    <div className="flex flex-col sm:flex-row gap-6">
       {publication.imageUrl && (
-        <div className="w-1/4 min-w-[160px] relative">
+        <div className="w-full sm:w-1/4 min-w-[160px] relative">
           <Image
             src={publication.imageUrl}
             alt={publication.title}


### PR DESCRIPTION
Entries in portfolio and publications sections become a column with image and content for small width screens.

Before:
<img width="375" alt="Screenshot 2025-01-11 at 1 52 46 PM" src="https://github.com/user-attachments/assets/705e5568-66fa-4d73-9199-9ceb5e10c3db" />

After:
<img width="371" alt="Screenshot 2025-01-11 at 1 53 09 PM" src="https://github.com/user-attachments/assets/2207754d-39fb-4951-932f-1f3c178e507c" />
