### PR TITLE
feat: make the images able to be opened in a popup window

### DIFF
--- a/src/components/image-viewer.tsx
+++ b/src/components/image-viewer.tsx
@@ -14,7 +14,6 @@ export function ImageViewer({ isOpen, imageUrl, alt, onClose }: ImageViewerProps
   
   useEffect(() => {
     if (isOpen) {
-      // Small timeout to ensure the animation works correctly
       setTimeout(() => {
         setAnimationClass('opacity-100 scale-100');
       }, 10);
@@ -23,7 +22,6 @@ export function ImageViewer({ isOpen, imageUrl, alt, onClose }: ImageViewerProps
     }
   }, [isOpen]);
 
-  // Close on escape key press
   useEffect(() => {
     if (!isOpen) return;
     
@@ -54,4 +52,4 @@ export function ImageViewer({ isOpen, imageUrl, alt, onClose }: ImageViewerProps
       </div>
     </div>
   );
-} 
+}

--- a/src/components/image-viewer.tsx
+++ b/src/components/image-viewer.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+
+interface ImageViewerProps {
+  isOpen: boolean;
+  imageUrl: string;
+  alt: string;
+  onClose: () => void;
+}
+
+export function ImageViewer({ isOpen, imageUrl, alt, onClose }: ImageViewerProps) {
+  const [animationClass, setAnimationClass] = useState('opacity-0 scale-95');
+  
+  useEffect(() => {
+    if (isOpen) {
+      // Small timeout to ensure the animation works correctly
+      setTimeout(() => {
+        setAnimationClass('opacity-100 scale-100');
+      }, 10);
+    } else {
+      setAnimationClass('opacity-0 scale-95');
+    }
+  }, [isOpen]);
+
+  // Close on escape key press
+  useEffect(() => {
+    if (!isOpen) return;
+    
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div 
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm" 
+      onClick={onClose}
+    >
+      <div className={`transition-all duration-300 ease-in-out ${animationClass} max-w-[90vw] max-h-[90vh]`}>
+        <div className="relative">
+          <img 
+            src={imageUrl} 
+            alt={alt} 
+            className="max-h-[85vh] max-w-[85vw] object-contain rounded-lg shadow-2xl" 
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/components/portfolio-entry.tsx
+++ b/src/components/portfolio-entry.tsx
@@ -1,18 +1,35 @@
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 import { ArrowUpRight } from "lucide-react";
 import { Portfolio } from "@/data/portfolio";
+import { ImageViewer } from "./image-viewer";
 
 export function PortfolioEntry({ portfolio }: { portfolio: Portfolio }) {
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false);
+
   return (
     <div className="flex flex-col sm:flex-row gap-6">
       {portfolio.imageUrl && (
         <div className="w-1/4 min-w-[160px] relative">
-          <Image
-            src={portfolio.imageUrl}
+          <div 
+            className="cursor-pointer hover:opacity-90 transition-opacity"
+            onClick={() => setIsImageViewerOpen(true)}
+          >
+            <Image
+              src={portfolio.imageUrl}
+              alt={portfolio.title}
+              width={160}
+              height={200}
+              className="rounded-lg"
+            />
+          </div>
+          <ImageViewer 
+            isOpen={isImageViewerOpen}
+            imageUrl={portfolio.imageUrl}
             alt={portfolio.title}
-            width={160}
-            height={200}
-            className="rounded-lg"
+            onClose={() => setIsImageViewerOpen(false)}
           />
         </div>
       )}

--- a/src/components/profile-section.tsx
+++ b/src/components/profile-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import {
   Github,

--- a/src/components/profile-section.tsx
+++ b/src/components/profile-section.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import {
   Github,

--- a/src/components/publication-entry.tsx
+++ b/src/components/publication-entry.tsx
@@ -1,22 +1,39 @@
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 import { ArrowUpRight } from "lucide-react";
 import { Publication } from "@/data/publication";
+import { ImageViewer } from "./image-viewer";
 
 export function PublicationEntry({
   publication,
 }: {
   publication: Publication;
 }) {
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false);
+
   return (
     <div className="flex flex-col sm:flex-row gap-6">
       {publication.imageUrl && (
         <div className="w-full sm:w-1/4 min-w-[160px] relative">
-          <Image
-            src={publication.imageUrl}
+          <div 
+            className="cursor-pointer hover:opacity-90 transition-opacity"
+            onClick={() => setIsImageViewerOpen(true)}
+          >
+            <Image
+              src={publication.imageUrl}
+              alt={publication.title}
+              width={160}
+              height={200}
+              className="rounded-lg transition-all duration-300"
+            />
+          </div>
+          <ImageViewer 
+            isOpen={isImageViewerOpen}
+            imageUrl={publication.imageUrl}
             alt={publication.title}
-            width={160}
-            height={200}
-            className="rounded-lg transition-all duration-300"
+            onClose={() => setIsImageViewerOpen(false)}
           />
         </div>
       )}


### PR DESCRIPTION
What a great template!

I did this because sometimes you want people to see the pictures like Kaolin :)

![CleanShot 2025-03-27 at 00 31 54](https://github.com/user-attachments/assets/16214376-663d-4ec0-b768-8bdaa152caf5)

As well, here's proof that `npm build` is good :smile:

```
npm build && npm start

> research-website-template@0.1.0 build /Users/vincen/projects/open-source/research-website-template
> next build

   ▲ Next.js 15.1.3

   Creating an optimized production build ...
 ✓ Compiled successfully

./src/components/image-viewer.tsx
47:11  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
 ✓ Linting and checking validity of types 
 ✓ Collecting page data    
 ✓ Generating static pages (5/5)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (app)                              Size     First Load JS
┌ ○ /                                    8.73 kB         114 kB
└ ○ /_not-found                          981 B           106 kB
+ First Load JS shared by all            105 kB
  ├ chunks/871-504a435d774fee65.js       50.5 kB
  ├ chunks/cdea6b85-c195ca6c90282d8b.js  52.9 kB
  └ other shared chunks (total)          1.91 kB


○  (Static)  prerendered as static content


> research-website-template@0.1.0 start /Users/vincen/projects/open-source/research-website-template
> next start

   ▲ Next.js 15.1.3
   - Local:        http://localhost:3000
   - Network:      http://*************:3000

 ✓ Starting...
 ✓ Ready in 382ms

```
